### PR TITLE
Spec: define _desktopdir if not already

### DIFF
--- a/src/grpn.spec
+++ b/src/grpn.spec
@@ -1,3 +1,7 @@
+%if %{!?_desktopdir:1}
+%define _desktopdir %{_datadir}/applications
+%endif
+
 Name:		grpn
 Version:	1.4.0
 Release:	1%{?dist}


### PR DESCRIPTION
Some distros (Fedora 25) don't define _desktopdir,
so define it if it's not already defined.

Signed-off-by: Nathaniel Clark <Nathaniel.Clark@misrule.us>